### PR TITLE
Add support for embedded svg tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,12 @@ console.log(output);
 You can use specific PlantUML server by the option 'baseUrl'.
 (The default is `https://www.plantuml.com/plantuml/png`)
 
+You can specify to render the diagram as image tag (type: "image") or as embedded svg object which supports links and to select text within the diagram (type: "svg"). To allow svg as HTML element in markdown you require a plugin like [rehype-raw](https://github.com/rehypejs/rehype-raw).
+
 If you want to use SVG, you can configure like following.
 
 ```javascript
-remark().use(simplePlantUML, { baseUrl: "https://www.plantuml.com/plantuml/svg" }).processSync(input);
+remark().use(simplePlantUML, { baseUrl: "https://www.plantuml.com/plantuml/svg", type: "svg" }).processSync(input);
 ```
 
 ## Integration

--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@ const visit = require("unist-util-visit");
 const plantumlEncoder = require("plantuml-encoder");
 
 const DEFAULT_OPTIONS = {
-  baseUrl: "https://www.plantuml.com/plantuml/png"
+  baseUrl: "https://www.plantuml.com/plantuml/png",
+  type: "image"
 };
 
 /**
@@ -23,10 +24,19 @@ function remarkSimplePlantumlPlugin(pluginOptions) {
       let { lang, value, meta } = node;
       if (!lang || !value || lang !== "plantuml") return;
 
-      node.type = "image";
-      node.url = `${options.baseUrl.replace(/\/$/, "")}/${plantumlEncoder.encode(value)}`;
+      let url = `${options.baseUrl.replace(/\/$/, "")}/${plantumlEncoder.encode(value)}`;
+
+      if (options.type === "image") {
+        node.type = "image";
+        node.url = url;
+      } else if (options.type === "svg") {
+        node.type = "paragraph";
+        node.children = [{ value: `<object type="image/svg+xml" data="${url}" />`, type: "html" }];
+      }
+
       node.alt = meta;
       node.meta = undefined;
+
     });
     return syntaxTree;
   };


### PR DESCRIPTION
Add support to specify if to render the diagram as image tag (type: "image") or as embedded svg object which supports links and to select text within the diagram (type: "svg"). To allow svg as HTML element in markdown you require a plugin like [rehype-raw](https://github.com/rehypejs/rehype-raw).

This should also solves the following issues:
https://github.com/akebifiky/remark-simple-plantuml/issues/5
https://github.com/akebifiky/remark-simple-plantuml/issues/6
